### PR TITLE
Support unary - operator for SMIs

### DIFF
--- a/lib/js/platform/base/index.js
+++ b/lib/js/platform/base/index.js
@@ -123,6 +123,9 @@ Base.prototype.optimize = function optimize(ssa) {
     // Replace store property/load property with a stub call
     this.spliceCFG(block, this.replaceProp);
 
+    // unary = stub unary
+    this.spliceCFG(block, this.replaceUnary);
+
     // binary = stub binary
     this.spliceCFG(block, this.replaceBinary);
 
@@ -194,6 +197,27 @@ Base.prototype.replaceFn = function replaceFn(instr) {
   ]);
   return {
     list: [ code, arg, call ],
+    replace: call
+  };
+};
+
+Base.prototype.replaceUnary = function replaceUnary(instr) {
+  if (instr.type !== 'unary')
+    return;
+
+  var state = this._baseState;
+  var inputs = instr.removeAllInputs();
+
+  var op = inputs[0].id;
+  var src = this.instr('pushArg', [ inputs[1] ]);
+  var call = this.instr('callStub', [
+    state.createJS('stub'),
+    state.createJS('unary/' + op),
+    state.createJS(1)
+  ]);
+
+  return {
+    list: [ src, call ],
     replace: call
   };
 };

--- a/lib/js/platform/base/instructions.js
+++ b/lib/js/platform/base/instructions.js
@@ -52,6 +52,11 @@ exports.get = function get() {
     alignStubStack: { inputs: [ js ], output: null },
     runtimeId: { inputs: [ js ], output: reg, shallow: true },
     ic: { inputs: [ ], output: reg, shallow: true },
+    unary: {
+      inputs: [ js, reg ],
+      output: out,
+      shallow: true
+    },
     binary: {
       inputs: [ js, reg, reg ],
       output: out,
@@ -63,6 +68,8 @@ exports.get = function get() {
     isSmi: { inputs: [ reg ], output: null, shallow: true },
     checkOverflow: { inputs: [], output: null, shallow: true },
     reverseBranch: { inputs: [], output: null, shallow: true },
+
+    smiNeg: { inputs: [ reg ], output: reg, shallow: true },
 
     smiUntag: { inputs: [ reg ], output: reg, shallow: true, tainted: true },
     smiAdd: { inputs: [ reg, reg ], output: reg, shallow: true },

--- a/lib/js/platform/base/stub.js
+++ b/lib/js/platform/base/stub.js
@@ -25,6 +25,7 @@ function initStubs() {
   propertyStubs.call(this);
   allocStubs.call(this);
   typeStubs.call(this);
+  unaryStubs.call(this);
   binaryStubs.call(this);
 }
 
@@ -373,6 +374,37 @@ function typeStubs() {
         runtime: 'coerce/' + type,
         mapOff: Base.offsets.map
       }
+    });
+  }, this);
+}
+
+function unaryStubs() {
+  var ops = [ '-' ];
+  ops.forEach(function(op) {
+    this.declareStub('unary/' + op, function() {/*
+      block UnaryExpression -> SrcSmi, SrcNonSmi
+        src = loadStubArg %0
+        isSmi src
+
+      block SrcSmi -> Overflow, Success
+        #if op === '-'
+          r = smiNeg src
+        #else
+          brk
+        #endif
+        checkOverflow
+
+      block Success
+        ret r
+
+      block SrcNonSmi -> Overflow
+      block Overflow
+        // not SMI
+        brk
+    */}, {
+    locals: {
+      op: op
+    }
     });
   }, this);
 }

--- a/lib/js/platform/x64/index.js
+++ b/lib/js/platform/x64/index.js
@@ -277,6 +277,14 @@ X64.prototype.genIsSmi = function genIsSmi(instr) {
   masm.isSmi(instr.inputs[0].id);
 };
 
+X64.prototype.genSmiNeg = function genSmiNeg(instr) {
+  var masm = this.masm();
+  var src = instr.inputs[0].id;
+  var dst = instr.output.id;
+
+  masm.neg(dst, src);
+};
+
 X64.prototype.genSmiAdd = function genSmiAdd(instr) {
   var masm = this.masm();
   var left = instr.inputs[0].id;

--- a/test/api-test.js
+++ b/test/api-test.js
@@ -20,12 +20,18 @@ describe('js.js API', function() {
   }
 
   describe('basics', function() {
-    it('should do basic binary expression', function() {
-      var fn = compile(function() {
-        (1 * 2) + (3 - 6);
-      });
+   it('should do basic unary expression', function() {
+      var fn = compile(function() { -1 });
       r.heap.gc();
       assert.equal(fn.call(null, []).cast().value(), -1);
+    });
+
+    it('should do basic binary expression', function() {
+      var fn = compile(function() {
+        (1 * 2) + (-3 - 6);
+      });
+      r.heap.gc();
+      assert.equal(fn.call(null, []).cast().value(), -7);
     });
 
     it('should do basic binary with spills', function() {


### PR DESCRIPTION
This change adds basic unary -/minus operator support for SMIs only (e.g. -'7' will error).

``` shell
> -7 + 2
-5
> -'7'
Trace/BPT trap: 5 (OS X)
```
